### PR TITLE
Fix dependency references.

### DIFF
--- a/rebar3_riak_core_rebar.config.tpl
+++ b/rebar3_riak_core_rebar.config.tpl
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 
 {deps, [
+    {cuttlefish, {git, "git://github.com/tsloughter/cuttlefish", {branch, "develop"}}},
     {pbkdf2, {git, "git://github.com/marianoguerra/erlang-pbkdf2-no-history", {branch, "master"}}},
     {exometer_core, {git, "git://github.com/basho/exometer_core.git", {branch, "th/correct-dependencies"}}},
     {riak_core, {git, "git://github.com/basho/riak_core", {branch, "develop"}}}
@@ -40,7 +41,7 @@
 
 {plugins, [
     {rebar3_run, {git, "git://github.com/tsloughter/rebar3_run.git", {branch, "master"}}},
-    {rebar3_cuttlefish, {git, "git@github.com:tsloughter/rebar3_cuttlefish.git", {branch, "master"}}}
+    {rebar3_cuttlefish, {git, "git://github.com/tsloughter/rebar3_cuttlefish.git", {branch, "master"}}}
 ]}.
 
 {profiles, [{prod, [{relx, [{dev_mode, false},


### PR DESCRIPTION
Use anonymous-accessible <code>rebar3_cuttlefish</code> repo. Add `cuttlefish' fork
dependency known to work with rebar3.
