### PR TITLE
remove unneeded hooks and deps

### DIFF
--- a/rebar3_riak_core_rebar.config.tpl
+++ b/rebar3_riak_core_rebar.config.tpl
@@ -41,7 +41,6 @@
 ]}.
 
 {plugins, [
-    {rebar3_run, {git, "git://github.com/tsloughter/rebar3_run.git", {branch, "master"}}},
     {rebar3_cuttlefish, {git, "git://github.com/tsloughter/rebar3_cuttlefish.git", {branch, "master"}}}
 ]}.
 
@@ -92,4 +91,8 @@
           {platform_define, "^[0-9]+", namespaced_types},
           {platform_define, "^R15", "old_hash"}]}
   ]}
+
+  {override, setup, [{post_hooks, []}, {deps, []}]},
+  {override, parse_trans, [{deps, []}]},
+  {override, folsom, [{deps, [{bear, {git, "git://github.com/boundary/bear.git", {tag, "0.8.2"}}}]}]}
  ]}.


### PR DESCRIPTION
Without overriding `setup`'s post hooks it won't build. I also get rid of the dependencies on `edown` in deps since it isn't needed. Also, `rebar3_run` is best kept in the global config under `~/.config/rebar3/rebar.config`. It can be annoying for users to have development plugins forced on them in the config and should instead stick to only including plugins required for building the project, and put any others in your global config.
